### PR TITLE
Core 66/add static hosted bucket and automation

### DIFF
--- a/.github/workflows/deploy-to-s3.yml
+++ b/.github/workflows/deploy-to-s3.yml
@@ -23,5 +23,4 @@ jobs:
         role-to-assume: ${{ secrets.AWS_OIDC_RUNNER_ROLE }}
     - name: Sync to S3
       if: github.ref == 'refs/heads/main' # Only sync static contents on merges into main branch
-      run: |
-        aws s3 sync . s3://pyscript-static/
+      run: aws s3 sync . s3://pyscript-static/ --exclude ".*" # Exclude hidden files


### PR DESCRIPTION
Pushes the root directory of this repo to the S3 bucket [here](http://pyscript-static.s3-website-us-east-1.amazonaws.com/).

Ignores hidden and meta files. Uses a cloud runner and AWS OIDC authentication with very limited scope. More details on that [here](https://github.com/anaconda/infra/pull/1991).

Ideally there'd be PR-based testing and linting/validation of the html before deployment. Also we can't use branch protection rules or other advanced features because it's private/not in our org.