### PR TITLE
Split aws sync into two commands; make sure hidden security.txt is synced

### DIFF
--- a/.github/workflows/deploy-to-s3.yml
+++ b/.github/workflows/deploy-to-s3.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
 
 jobs:
   deploy:


### PR DESCRIPTION
Alright this took a bit of testing as you can see from the commits.

It's a bit tricky because I want it to delete items in `assets/` that may be removed so we don't have to manually, but when I tried that in the root of the bucket, it deleted all the builds and examples too...

So I specified more targeted commands and it seems to work fine. We'll have to see how scalable this is as the project grows, however. It may be that we need to restructure a bit, although this is the only repo that executes `s3 sync` in the root directory so likely the only cause of issues.

I think this setup is perfectly safe but we may need to review from time to time if the bucket structure sees major changes.