### PR TITLE
Small fix for link color when hovering the Documentation section

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -210,6 +210,10 @@ a.examples-block:hover {
     color: #2C2E34;
 }
 
+.dialog:hover a {
+    color: #2C2E34;
+}
+
 .dialog p {
     font-size: 0.85rem;
     line-height: 1.5;


### PR DESCRIPTION
While looking at the pyscript.net I noticed that when you hover the documentation section, the link doesn't change color:

![before](https://user-images.githubusercontent.com/3131401/199517701-352f296a-2914-4c19-9766-de368e56ce5d.png)

This PR makes the link color to be dark similar to what we do with the icons

![Screenshot from 2022-11-02 14-31-01](https://user-images.githubusercontent.com/3131401/199517800-f34059e2-1024-4dc8-8282-21d9d4f08adc.png)
