### PR TITLE
Add 404 page

### DIFF
--- a/.github/workflows/deploy-to-s3.yml
+++ b/.github/workflows/deploy-to-s3.yml
@@ -23,5 +23,5 @@ jobs:
         role-to-assume: ${{ secrets.AWS_OIDC_RUNNER_ROLE }}
     - name: Sync to S3
       run: | # Sync index and security txt, exclude hidden files; Sync assets and remove any that aren't in source
-        aws s3 sync . s3://pyscript.net/ --exclude ".*" --include ".well-known/security.txt" --include "index.html"
+        aws s3 sync . s3://pyscript.net/ --exclude ".*" --include ".well-known/security.txt" --include "index.html" --include "error.html"
         aws s3 sync --delete assets/ s3://pyscript.net/assets/ 

--- a/error.html
+++ b/error.html
@@ -1,0 +1,141 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+
+		<title>PyScript | Not Found</title>
+		<meta name="description" content="PyScript">
+		<meta name="author" content="Anaconda Inc.">
+		<meta property="og:title" content="Pyscript.net">
+		<meta property="og:type" content="website">
+		<meta property="og:description" content="Run Python code in your HTML.">
+		<meta property="og:image" content="assets/images/pyscript-preview.png">
+
+        <link rel="icon" href="/assets/images/favicon.ico">
+		<link rel="apple-touch-icon" href="/assets/images/apple-touch-icon.png">
+
+        <link rel="preconnect" href="https://fonts.googleapis.com">
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+        <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;700&display=swap" rel="stylesheet">
+
+		<link rel="stylesheet" href="assets/css/main.css?v=1.3">
+	</head>
+
+	<body>
+        <main class="main">
+
+             <!-- begin header -->
+            <header class="site-header">
+                <div class="logo">
+                    <img src="assets/images/pyscript-sticker-black.svg">
+                    <strong class="subhead">Run Python in Your HTML</strong>
+                </div>
+            </header>
+            <!-- end header -->
+
+            <section class="content">
+
+                <!-- begin terminal window -->
+                <div class="terminal">
+                    <div class="menu">
+                        <div class="window-buttons close"></div>
+                        <div class="window-buttons minimize"></div>
+                        <div class="window-buttons zoom"></div>
+                    </div>
+                    <div class="screen">
+                        <div class="code">
+                            <pre id="typewriter">
+                              Hmm... I can't seem to find that page.
+                            </pre>
+                            
+                            <p class="line1">Not Found<span class="cursor1">|</span></p>
+                            <p class="line2">The page that you looked for could not be found<span class="cursor2">|</span></p>
+                        </div>
+                    </div>
+                </div
+                <!-- end terminal window -->
+
+                <!-- begin examples badge -->
+                <a href="https://pyscript.net/examples/" target="_blank" rel="noreferrer noopener" class="examples-block">
+                    <div class="glyph">
+                        <svg width="16px" height="16px" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="currentColor" class="bi bi-grid">
+                        <path d="M1 2.5A1.5 1.5 0 0 1 2.5 1h3A1.5 1.5 0 0 1 7 2.5v3A1.5 1.5 0 0 1 5.5 7h-3A1.5 1.5 0 0 1 1 5.5v-3zM2.5 2a.5.5 0 0 0-.5.5v3a.5.5 0 0 0 .5.5h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 0 0-.5-.5h-3zm6.5.5A1.5 1.5 0 0 1 10.5 1h3A1.5 1.5 0 0 1 15 2.5v3A1.5 1.5 0 0 1 13.5 7h-3A1.5 1.5 0 0 1 9 5.5v-3zm1.5-.5a.5.5 0 0 0-.5.5v3a.5.5 0 0 0 .5.5h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 0 0-.5-.5h-3zM1 10.5A1.5 1.5 0 0 1 2.5 9h3A1.5 1.5 0 0 1 7 10.5v3A1.5 1.5 0 0 1 5.5 15h-3A1.5 1.5 0 0 1 1 13.5v-3zm1.5-.5a.5.5 0 0 0-.5.5v3a.5.5 0 0 0 .5.5h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 0 0-.5-.5h-3zm6.5.5A1.5 1.5 0 0 1 10.5 9h3a1.5 1.5 0 0 1 1.5 1.5v3a1.5 1.5 0 0 1-1.5 1.5h-3A1.5 1.5 0 0 1 9 13.5v-3zm1.5-.5a.5.5 0 0 0-.5.5v3a.5.5 0 0 0 .5.5h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 0 0-.5-.5h-3z"/>
+                        </svg>
+                    </div>
+                    <div>
+                        <h2>Examples</h2>
+                        <p><span>Click here</span> for example projects</p>
+                    </div>
+
+                </a>
+                <!-- end examples badge -->
+
+                <!-- begin dialog content -->
+                <div class="dialogs">
+
+                    <!-- begin documentation dropdown -->
+                    <a href="https://docs.pyscript.net/latest/" target="_blank" rel="noreferrer noopener" class="dialog" tabindex="1">
+                        <div class="glyph">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--! Font Awesome Pro 6.1.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. --><path d="M448 336v-288C448 21.49 426.5 0 400 0H96C42.98 0 0 42.98 0 96v320c0 53.02 42.98 96 96 96h320c17.67 0 32-14.33 32-31.1c0-11.72-6.607-21.52-16-27.1v-81.36C441.8 362.8 448 350.2 448 336zM143.1 128h192C344.8 128 352 135.2 352 144C352 152.8 344.8 160 336 160H143.1C135.2 160 128 152.8 128 144C128 135.2 135.2 128 143.1 128zM143.1 192h192C344.8 192 352 199.2 352 208C352 216.8 344.8 224 336 224H143.1C135.2 224 128 216.8 128 208C128 199.2 135.2 192 143.1 192zM384 448H96c-17.67 0-32-14.33-32-32c0-17.67 14.33-32 32-32h288V448z"/></svg>
+                        </div>
+
+                        <div>
+                            <h2>Documentation</h2>
+                            <p>Click here for PyScript documentation</p>
+                        </div>
+                    </a>
+                    <!-- end documentation dropdown -->
+
+                    <!-- begin installation dropdown -->
+                    <div class="dialog dropdown" tabindex="2">
+                        <div class="glyph">
+                            <svg width="24px" height="24px" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                            <path fill="none" stroke="#fff" stroke-width="2" d="M9,22 L15,2 M17,17 L22,12 L17,7 M7,17 L2,12 L7,7"/>
+                            </svg>
+                        </div>
+
+                        <div>
+                            <h2>Install</h2>
+                            <p>Click here for instructions</p>
+                        </div>
+
+                        <div class="dropdown-content">
+                            <i class="close" tabindex="2"></i>
+                            <div class="inner">
+                                <p style="font-size:1.15rem;padding-bottom: 0;">Just kidding, you don't need to install anything. &#128515; </p>
+
+                                <p>To use PyScript you can either <a href="https://github.com/pyscript/pyscript/archive/refs/heads/main.zip">download</a> it and follow the instructions, or add the following lines to your page.</p>
+                                <code class="pre">
+                                    &lt;link rel="stylesheet" href="https://pyscript.net/latest/pyscript.css" /&gt;<br>
+                                    &lt;script defer src="https://pyscript.net/latest/pyscript.js"&gt;&lt;/script&gt;
+                                </code>
+                                <p>Click <a href="https://docs.pyscript.net/latest/tutorials/getting-started.html" target="_blank">here</a> for more info on how to use PyScript.</p>
+                            </div>
+                        </div>
+                    </div>
+                    <!-- end installation dropdown -->
+
+                </div>
+                <!-- end dialog content -->
+                <footer class="site-footer">
+                    <a href="https://github.com/pyscript/pyscript" class="footer-button" target="_blank">
+                        <div class="icon">
+                            <svg width="1024px" height="1024px" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" class="icon">
+                            <path d="M511.6 76.3C264.3 76.2 64 276.4 64 523.5 64 718.9 189.3 885 363.8 946c23.5 5.9 19.9-10.8 19.9-22.2v-77.5c-135.7 15.9-141.2-73.9-150.3-88.9C215 726 171.5 718 184.5 703c30.9-15.9 62.4 4 98.9 57.9 26.4 39.1 77.9 32.5 104 26 5.7-23.5 17.9-44.5 34.7-60.8-140.6-25.2-199.2-111-199.2-213 0-49.5 16.3-95 48.3-131.7-20.4-60.5 1.9-112.3 4.9-120 58.1-5.2 118.5 41.6 123.2 45.3 33-8.9 70.7-13.6 112.9-13.6 42.4 0 80.2 4.9 113.5 13.9 11.3-8.6 67.3-48.8 121.3-43.9 2.9 7.7 24.7 58.3 5.5 118 32.4 36.8 48.9 82.7 48.9 132.3 0 102.2-59 188.1-200 212.9a127.5 127.5 0 0 1 38.1 91v112.5c.8 9 0 17.9 15 17.9 177.1-59.7 304.6-227 304.6-424.1 0-247.2-200.4-447.3-447.5-447.3z"/>
+                            </svg>
+                        </div>
+                        <div>
+                            <span>Project home</span>
+                        </div>
+                    </a>
+
+                    <div class="copyright">
+                        <p>&copy; 2022 <a href="https://anaconda.com" target="_blank">Anaconda</a>, Inc.
+                    </div>
+                </footer>
+            </section>
+        </main>
+	</body>
+</html>
+

--- a/index.html
+++ b/index.html
@@ -129,7 +129,7 @@
                                     &lt;link rel="stylesheet" href="https://pyscript.net/latest/pyscript.css" /&gt;<br>
                                     &lt;script defer src="https://pyscript.net/latest/pyscript.js"&gt;&lt;/script&gt;
                                 </code>
-                                <p>Click <a href="https://github.com/pyscript/pyscript/blob/main/docs/tutorials/getting-started.md" target="_blank">here</a> for more info on how to use PyScript.</p>
+                                <p>Click <a href="https://docs.pyscript.net/latest/tutorials/getting-started.html" target="_blank">here</a> for more info on how to use PyScript.</p>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
I noticed that we don't have a 404 page, this page adds an error.html that will be used when users try to look for something but doesn't exist. It copies most of the style from the index page, the only difference is removing tracking (I assume we don't want it in this page?) and  the main text from the index page.

This is how the error page looks like:

![error page](https://user-images.githubusercontent.com/3131401/203171258-76902106-9aad-4ecf-ab8f-f466202ea556.mov)


Closes: #9