### PR TITLE
Don't use /latest, update link to docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,10 +141,10 @@
 
                                 <p>To use PyScript you can either <a href="https://github.com/pyscript/pyscript/archive/refs/heads/main.zip">download</a> it and follow the instructions, or add the following lines to your page.</p>
                                 <code class="pre">
-                                    &lt;link rel="stylesheet" href="https://pyscript.net/latest/pyscript.css" /&gt;<br>
-                                    &lt;script defer src="https://pyscript.net/latest/pyscript.js"&gt;&lt;/script&gt;
+                                    &lt;link rel="stylesheet" href="https://pyscript.net/releases/2023.11.1/core.css" /&gt;<br>
+                                    &lt;script type="module" src="https://pyscript.net/releases/2023.11.1/core.js"&gt;&lt;/script&gt;
                                 </code>
-                                <p>Click <a href="https://docs.pyscript.net/latest/tutorials/getting-started.html" target="_blank">here</a> for more info on how to use PyScript.</p>
+                                <p>Click <a href="https://docs.pyscript.net/latest/beginning-pyscript/" target="_blank">here</a> for more info on how to use PyScript.</p>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
The main page's "install" section uses an outdated link format, and the link to the getting-started docs is now out-of-date. Fixes both of those.

Fixes #53.