### PR TITLE
Update docs link for GH Pages redirect

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,7 +109,7 @@
                 <div class="dialogs">
 
                     <!-- begin documentation dropdown -->
-                    <a href="https://docs.pyscript.net/docs/latest/" target="_blank" rel="noreferrer noopener" class="dialog" tabindex="1">
+                    <a href="https://pyscript.github.io/docs/latest/" target="_blank" rel="noreferrer noopener" class="dialog" tabindex="1">
                         <div class="glyph">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--! Font Awesome Pro 6.1.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. --><path d="M448 336v-288C448 21.49 426.5 0 400 0H96C42.98 0 0 42.98 0 96v320c0 53.02 42.98 96 96 96h320c17.67 0 32-14.33 32-31.1c0-11.72-6.607-21.52-16-27.1v-81.36C441.8 362.8 448 350.2 448 336zM143.1 128h192C344.8 128 352 135.2 352 144C352 152.8 344.8 160 336 160H143.1C135.2 160 128 152.8 128 144C128 135.2 135.2 128 143.1 128zM143.1 192h192C344.8 192 352 199.2 352 208C352 216.8 344.8 224 336 224H143.1C135.2 224 128 216.8 128 208C128 199.2 135.2 192 143.1 192zM384 448H96c-17.67 0-32-14.33-32-32c0-17.67 14.33-32 32-32h288V448z"/></svg>
                         </div>
@@ -144,7 +144,7 @@
                                     &lt;link rel="stylesheet" href="https://pyscript.net/releases/2023.11.1/core.css" /&gt;<br>
                                     &lt;script type="module" src="https://pyscript.net/releases/2023.11.1/core.js"&gt;&lt;/script&gt;
                                 </code>
-                                <p>Click <a href="https://docs.pyscript.net/docs/latest/beginning-pyscript/" target="_blank">here</a> for more info on how to use PyScript.</p>
+                                <p>Click <a href="https://pyscript.github.io/docs/latest/beginning-pyscript/" target="_blank">here</a> for more info on how to use PyScript.</p>
                             </div>
                         </div>
                     </div>

--- a/index.html
+++ b/index.html
@@ -109,7 +109,7 @@
                 <div class="dialogs">
 
                     <!-- begin documentation dropdown -->
-                    <a href="https://docs.pyscript.net/latest/" target="_blank" rel="noreferrer noopener" class="dialog" tabindex="1">
+                    <a href="https://docs.pyscript.net/docs/latest/" target="_blank" rel="noreferrer noopener" class="dialog" tabindex="1">
                         <div class="glyph">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--! Font Awesome Pro 6.1.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. --><path d="M448 336v-288C448 21.49 426.5 0 400 0H96C42.98 0 0 42.98 0 96v320c0 53.02 42.98 96 96 96h320c17.67 0 32-14.33 32-31.1c0-11.72-6.607-21.52-16-27.1v-81.36C441.8 362.8 448 350.2 448 336zM143.1 128h192C344.8 128 352 135.2 352 144C352 152.8 344.8 160 336 160H143.1C135.2 160 128 152.8 128 144C128 135.2 135.2 128 143.1 128zM143.1 192h192C344.8 192 352 199.2 352 208C352 216.8 344.8 224 336 224H143.1C135.2 224 128 216.8 128 208C128 199.2 135.2 192 143.1 192zM384 448H96c-17.67 0-32-14.33-32-32c0-17.67 14.33-32 32-32h288V448z"/></svg>
                         </div>
@@ -144,7 +144,7 @@
                                     &lt;link rel="stylesheet" href="https://pyscript.net/releases/2023.11.1/core.css" /&gt;<br>
                                     &lt;script type="module" src="https://pyscript.net/releases/2023.11.1/core.js"&gt;&lt;/script&gt;
                                 </code>
-                                <p>Click <a href="https://docs.pyscript.net/latest/beginning-pyscript/" target="_blank">here</a> for more info on how to use PyScript.</p>
+                                <p>Click <a href="https://docs.pyscript.net/docs/latest/beginning-pyscript/" target="_blank">here</a> for more info on how to use PyScript.</p>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
Swapping to Github Pages and I believe we'd break some links without these changes.