### PR TITLE
Quick FIX: PyScript release under "install" section in Home

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,8 +141,8 @@
 
                                 <p>To use PyScript you can either <a href="https://github.com/pyscript/pyscript/archive/refs/heads/main.zip">download</a> it and follow the instructions, or add the following lines to your page.</p>
                                 <code class="pre">
-                                    &lt;link rel="stylesheet" href="https://pyscript.net/releases/2023.11.1/core.css" /&gt;<br>
-                                    &lt;script type="module" src="https://pyscript.net/releases/2023.11.1/core.js"&gt;&lt;/script&gt;
+                                    &lt;link rel="stylesheet" href="https://pyscript.net/releases/2024.1.1/core.css" /&gt;<br>
+                                    &lt;script type="module" src="https://pyscript.net/releases/2024.1.1/core.js"&gt;&lt;/script&gt;
                                 </code>
                                 <p>Click <a href="https://pyscript.github.io/docs/latest/beginning-pyscript/" target="_blank">here</a> for more info on how to use PyScript.</p>
                             </div>


### PR DESCRIPTION
This PR is a quick fix to reference the latest `2024.1.1` PyScript release under the "Install" section in the Home page.