### PR TITLE
Add padding & rounding to MicroPython terminal

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -762,3 +762,18 @@ a.examples-block:hover {
     background-color: #FDA803;
     color: #1D1D22;
 }
+
+
+/* ----------------------------------
+ MicroPython Terminal
+-----------------------------------*/
+
+.xterm {
+    padding-left: 1rem;
+    border-radius: 10px;
+    overflow-y: auto;
+}
+
+.xterm .xterm-viewport {
+    border-radius: 10px;
+}


### PR DESCRIPTION
This is a bit of a silly PR, but thought these few small changes would make the terminal match the rest of the site :) 

<img width="1650" alt="image" src="https://github.com/pyscript/pyscript.net/assets/25752941/8252f44f-1f49-492d-a342-d1f0d76a5de8">
