### PR TITLE
Update to 2024.6.1 release. TODO: fix REPL.

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1">
 
-		<title>PyScript is a platform for Python in the browser.</title>
+		<title>PyScript is an open source platform for Python in the browser.</title>
 		<meta name="description" content="PyScript">
 		<meta name="author" content="Anaconda Inc.">
 		<meta property="og:title" content="Pyscript.net">
@@ -32,8 +32,8 @@
             gtag('js', new Date());
             gtag('config', 'G-LKETQQ110J');
         </script>
-    <link rel="stylesheet" href="https://pyscript.net/releases/2024.5.2/core.css" />
-    <script type="module" src="https://pyscript.net/releases/2024.5.2/core.js"></script>
+    <link rel="stylesheet" href="https://pyscript.net/releases/2024.6.1/core.css" />
+    <script type="module" src="https://pyscript.net/releases/2024.6.1/core.js"></script>
 	</head>
 
 	<body>
@@ -43,7 +43,8 @@
             <header class="site-header">
                 <div class="logo">
                     <img src="assets/images/pyscript-sticker-black.svg">
-                    <strong class="subhead">PyScript is a platform for Python in the browser.</strong>
+                    <strong class="subhead">PyScript is an <u>open source</u>
+                    platform for <em>Python in the browser</em>.</strong>
                 </div>
             </header>
             <!-- end header -->
@@ -133,29 +134,17 @@
                     </a>
                     <!-- end examples badge -->
 
-
-                    <!-- begin installation dropdown -->
-                    <div class="dialog dropdown" tabindex="2">
-                        <div class="glyph">
-                            <svg width="24px" height="24px" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                            <path fill="none" stroke="#fff" stroke-width="2" d="M9,22 L15,2 M17,17 L22,12 L17,7 M7,17 L2,12 L7,7"/>
-                            </svg>
-                        </div>
-
-                        <div>
-                            <h2>Install</h2>
-                            <p>Click here for instructions.</p>
-                        </div>
-
-                        <div class="dropdown-content">
-                            <i class="close" tabindex="2"></i>
-                            <div class="inner">
-                                <p style="font-size:1.15rem;padding-bottom: 0;">Just kidding, you don't need to install anything. ;-) </p>
-                                <p><a href="https://docs.pyscript.net/" target="_blank">Read our docs</a> to learn how to use PyScript.</p>
-                            </div>
-                        </div>
-                    </div>
-                    <!-- end installation dropdown -->
+                    <!-- begin community badge -->
+                    <a href="https://discord.gg/HxvBtukrg2" target="_blank" rel="noreferrer noopener" class="dialog">
+                      <div class="glyph">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512"><!--!Font Awesome Free 6.5.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M64 64a64 64 0 1 1 128 0A64 64 0 1 1 64 64zM25.9 233.4C29.3 191.9 64 160 105.6 160h44.8c27 0 51 13.4 65.5 34.1c-2.7 1.9-5.2 4-7.5 6.3l-64 64c-21.9 21.9-21.9 57.3 0 79.2L192 391.2V464c0 26.5-21.5 48-48 48H112c-26.5 0-48-21.5-48-48V348.3c-26.5-9.5-44.7-35.8-42.2-65.6l4.1-49.3zM448 64a64 64 0 1 1 128 0A64 64 0 1 1 448 64zM431.6 200.4c-2.3-2.3-4.9-4.4-7.5-6.3c14.5-20.7 38.6-34.1 65.5-34.1h44.8c41.6 0 76.3 31.9 79.7 73.4l4.1 49.3c2.5 29.8-15.7 56.1-42.2 65.6V464c0 26.5-21.5 48-48 48H496c-26.5 0-48-21.5-48-48V391.2l47.6-47.6c21.9-21.9 21.9-57.3 0-79.2l-64-64zM272 240v32h96V240c0-9.7 5.8-18.5 14.8-22.2s19.3-1.7 26.2 5.2l64 64c9.4 9.4 9.4 24.6 0 33.9l-64 64c-6.9 6.9-17.2 8.9-26.2 5.2s-14.8-12.5-14.8-22.2V336H272v32c0 9.7-5.8 18.5-14.8 22.2s-19.3 1.7-26.2-5.2l-64-64c-9.4-9.4-9.4-24.6 0-33.9l64-64c6.9-6.9 17.2-8.9 26.2-5.2s14.8 12.5 14.8 22.2z"/></svg>
+                      </div>
+                      <div>
+                        <h2>Community</h2>
+                        <p>Connect with other PyScript users.</p>
+                      </div>
+                    </a>
+                    <!-- end community badge -->
 
                 </div>
                 <!-- end dialog content -->


### PR DESCRIPTION
This PR introduces two changes:

* Based on several pieces of feedback from PyCon - we have no direct link to our community channels on discord. This PR fixes this by replacing the joke-y superfluous "Install PyScript" button (hint: you don't install it) with a link to discord.
* Updated to PyScript 20204.6.1 - @WebReflection the opening example code that's "typed" into the console no longer looks right. Any idea what's going on?