### PR TITLE
Fix privacy authors but replacing Anaconda with PyScript Maintainers

### DIFF
--- a/privacy/index.html
+++ b/privacy/index.html
@@ -7,7 +7,7 @@
 
 		<title>PyScript's privacy policy .</title>
 		<meta name="description" content="PyScript">
-		<meta name="author" content="Anaconda Inc.">
+		<meta name="author" content="PyScript Maintainers">
 		<meta property="og:title" content="Pyscript.net">
 		<meta property="og:type" content="website">
 		<meta property="og:description" content="PyScript is a platform for Python in the browser.">
@@ -60,7 +60,7 @@
               <p>By opting in to receive communications from us via the
               PyScript.net website (<strong>"PyScript
               Communications"</strong>), you agree that you have read and
-              consent to this Section of Anaconda’s Privacy Policy, including
+              consent to this Section of the PyScript Project Privacy Policy, including
               the collection, use, and processing of your personal data as
               described herein.</p>
 


### PR DESCRIPTION
This PR implements the privacy authors changes discussed in #73 