### PR TITLE
Add Mailerlite newsletter signup to landing page, and specific /news page.

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,6 +149,10 @@
                 </div>
                 <!-- end dialog content -->
 
+                <!-- Newsletter sign-up form -->
+                <div class="ml-embedded" data-form="6Gk3CK" style="margin: 2rem auto 0; width: 340px;"></div>
+
+                <!-- Social media form -->
                 <div class="social">
                     <figure class="profile">
                         <svg width="256px" height="209px" viewBox="0 0 256 209" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" preserveAspectRatio="xMidYMid">
@@ -315,5 +319,14 @@ of people. Python is one of the
           document.getElementById("old-terminal").style.display = "block";
         }
         </script>
+    <!-- MailerLite Universal -->
+    <script>
+        (function(w,d,e,u,f,l,n){w[f]=w[f]||function(){(w[f].q=w[f].q||[])
+        .push(arguments);},l=d.createElement(e),l.async=1,l.src=u,
+        n=d.getElementsByTagName(e)[0],n.parentNode.insertBefore(l,n);})
+        (window,document,'script','https://assets.mailerlite.com/js/universal.js','ml');
+        ml('account', '1042482');
+    </script>
+    <!-- End MailerLite Universal -->
 	</body>
 </html>

--- a/news/index.html
+++ b/news/index.html
@@ -1,0 +1,99 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+
+		<title>Signup for PyScript's newsletter.</title>
+		<meta name="description" content="PyScript">
+		<meta name="author" content="PyScript Maintainers">
+		<meta property="og:title" content="Pyscript.net">
+		<meta property="og:type" content="website">
+		<meta property="og:description" content="PyScript is a platform for Python in the browser.">
+		<meta property="og:image" content="assets/images/pyscript-preview.png">
+
+        <link rel="icon" href="/assets/images/favicon.ico">
+		<link rel="apple-touch-icon" href="/assets/images/apple-touch-icon.png">
+
+        <link rel="preconnect" href="https://fonts.googleapis.com">
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+        <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;700&display=swap" rel="stylesheet">
+
+		<link rel="stylesheet" href="/assets/css/main.css?v=1.5">
+
+        <!-- Global site tag (gtag.js) - Google Analytics -->
+        <script async src="https://www.googletagmanager.com/gtag/js?id=G-LKETQQ110J"></script>
+        <script>
+            window.dataLayer = window.dataLayer || [];
+            function gtag() {
+                dataLayer.push(arguments);
+            }
+            gtag('js', new Date());
+            gtag('config', 'G-LKETQQ110J');
+        </script>
+    <link rel="stylesheet" href="https://pyscript.net/releases/2024.6.2/core.css" />
+    <script type="module" src="https://pyscript.net/releases/2024.6.2/core.js"></script>
+    <style>
+      h1, h2, p, ol, li {
+        margin: revert!important;
+        padding: revert!important;
+      }
+    </style>
+	</head>
+
+	<body>
+        <main class="main">
+
+             <!-- begin header -->
+            <header class="site-header">
+                <div class="logo">
+                    <img src="/assets/images/pyscript-sticker-black.svg">
+                </div>
+            </header>
+            <!-- end header -->
+
+            <section class="content">
+
+                
+                <div class="ml-embedded" data-form="6Gk3CK"></div>
+                <br/>
+
+
+
+                <footer class="site-footer">
+                    <a href="https://github.com/pyscript/pyscript" class="footer-button" target="_blank">
+                        <div class="icon">
+                            <svg width="1024px" height="1024px" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" class="icon">
+                            <path d="M511.6 76.3C264.3 76.2 64 276.4 64 523.5 64 718.9 189.3 885 363.8 946c23.5 5.9 19.9-10.8 19.9-22.2v-77.5c-135.7 15.9-141.2-73.9-150.3-88.9C215 726 171.5 718 184.5 703c30.9-15.9 62.4 4 98.9 57.9 26.4 39.1 77.9 32.5 104 26 5.7-23.5 17.9-44.5 34.7-60.8-140.6-25.2-199.2-111-199.2-213 0-49.5 16.3-95 48.3-131.7-20.4-60.5 1.9-112.3 4.9-120 58.1-5.2 118.5 41.6 123.2 45.3 33-8.9 70.7-13.6 112.9-13.6 42.4 0 80.2 4.9 113.5 13.9 11.3-8.6 67.3-48.8 121.3-43.9 2.9 7.7 24.7 58.3 5.5 118 32.4 36.8 48.9 82.7 48.9 132.3 0 102.2-59 188.1-200 212.9a127.5 127.5 0 0 1 38.1 91v112.5c.8 9 0 17.9 15 17.9 177.1-59.7 304.6-227 304.6-424.1 0-247.2-200.4-447.3-447.5-447.3z"/>
+                            </svg>
+                        </div>
+                        <div>
+                            <span>Source code</span>
+                        </div>
+                    </a>
+
+                    <div class="copyright">
+                        <p>Copyright &copy; 2022-present, PyScript Development Team - Originated at <a href="https://anaconda.com" target="_blank">Anaconda, Inc.</a> in 2022
+                    </div>
+                </footer>
+
+            </section>
+        </main>
+
+        <!-- BEGIN HEAP INTEGRATION -->
+		<script type="text/javascript">
+			window.heap=window.heap||[],heap.load=function(e,t){window.heap.appid=e,window.heap.config=t=t||{};var r=document.createElement("script");r.type="text/javascript",r.async=!0,r.src="https://cdn.heapanalytics.com/js/heap-"+e+".js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(r,a);for(var n=function(e){return function(){heap.push([e].concat(Array.prototype.slice.call(arguments,0)))}},p=["addEventProperties","addUserProperties","clearEventProperties","identify","resetIdentity","removeEventProperty","setEventProperties","track","unsetEventProperty"],o=0;o<p.length;o++)heap[p[o]]=n(p[o])};
+			heap.load("758475466");
+		</script>
+		<!-- END HEAP INTEGRATION -->
+    <!-- MailerLite Universal -->
+      <script>
+            (function(w,d,e,u,f,l,n){w[f]=w[f]||function(){(w[f].q=w[f].q||[])
+            .push(arguments);},l=d.createElement(e),l.async=1,l.src=u,
+            n=d.getElementsByTagName(e)[0],n.parentNode.insertBefore(l,n);})
+            (window,document,'script','https://assets.mailerlite.com/js/universal.js','ml');
+            ml('account', '1042482');
+      </script>
+    <!-- End MailerLite Universal -->
+	</body>
+</html>


### PR DESCRIPTION
This PR makes two changes, at the request of Dasha, so we can enable the signup to our impending PyScript news letter.

* The sign-up form is available on the homepage.
* There is a separate page containing just the sign-up form. It is this page which will be shared to existing folks. The links will be: https://pyscript.net/news

The homepage will end up like this:

![Screenshot 2024-09-26 at 16-20-59 PyScript is an open source platform for Python in the browser](https://github.com/user-attachments/assets/afa82cb5-a289-483f-a65d-4dc6fd4ddb37)

The separate /news landing page will look like this:

![Screenshot 2024-09-26 at 16-20-11 Signup for PyScript's newsletter](https://github.com/user-attachments/assets/893b9883-45fa-4d3c-9ac0-a9925aa2c04c)

